### PR TITLE
feat: official action ignores pin digest

### DIFF
--- a/default.json
+++ b/default.json
@@ -39,5 +39,19 @@
         ]
       }
     ]
+  },
+  "github-actions": {
+    "extends": [
+      "helpers:pinGitHubActionDigests"
+    ],
+    "packageRules": [
+      {
+        "groupName": "official actions",
+        "matchPackageNames": [
+          "/^actions//"
+        ],
+        "pinDigests": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
Ignore the digest when it comes to official GitHub Actions.

Because
 - I don't see much need to digest github official actions.
- There are a lot of dependencies, and we expect a large cost to manage them in Renovate.
