### PR TITLE
feat: platformAutomerge to true

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,7 +14,7 @@
     "shiron-dev"
   ],
   "stabilityDays": 3,
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "rangeStrategy": "bump",
   "packageRules": [
     {


### PR DESCRIPTION
Fixes #995

Change `platformAutomerge` to `true` in `default.json`.

* Modify `default.json` to set `platformAutomerge` to `true` instead of `false`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shiron-dev/renovate-config/pull/996?shareId=ca63a81f-6d14-48bc-98b3-caa8776de6fb).