### PR TITLE
feat: update shiron-dev's own deps immediately

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,13 @@
     "addLabels": [
       "major"
     ]
+  }, {
+    "description": "Update shiron-dev's own dependencies immediately without the release-age delay",
+    "matchPackageNames": [
+      "shiron-dev/**"
+    ],
+    "minimumReleaseAge": null,
+    "dependencyDashboardApproval": false
   }],
   "npm": {
     "extends": [


### PR DESCRIPTION
## 背景 / 課題

組織共通の `minimumReleaseAge: "3 days"` が **自組織の `shiron-dev/*` アクション/パッケージにも適用**されており、新しく出したばかりの内部アクションが 3 日間取り込まれませんでした。

このため、自己参照しているバージョン不整合が放置されます。実例として `shiron-dev/actions` の `renovate-deps-comment` が古い `setup-node`（pnpm 10.31.0 デフォルト）をピン留めしたままになり、Renovate が pnpm `^11` を要求するようになった結果 `ERR_PNPM_UNSUPPORTED_ENGINE` で CI が落ちました。

## 変更

`shiron-dev/**` にマッチする packageRule を追加し、内部依存は release-age 遅延・ダッシュボード承認なしで即時更新されるようにします。

```json
{
  "description": "Update shiron-dev's own dependencies immediately without the release-age delay",
  "matchPackageNames": ["shiron-dev/**"],
  "minimumReleaseAge": null,
  "dependencyDashboardApproval": false
}
```

## 検証

- `renovate-config-validator --strict default.json` → Config validated successfully
- `pnpm lint` (eslint) → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)