### PR TITLE
[codex] skip pinning actions self references

### DIFF
--- a/default.json
+++ b/default.json
@@ -45,6 +45,19 @@
     ],
     "minimumReleaseAge": null,
     "dependencyDashboardApproval": false
+  }, {
+    "description": "Keep shiron-dev/actions self-references on branch refs",
+    "matchManagers": [
+      "github-actions"
+    ],
+    "matchPackageNames": [
+      "shiron-dev/actions",
+      "shiron-dev/actions/**"
+    ],
+    "matchRepositories": [
+      "shiron-dev/actions"
+    ],
+    "pinDigests": false
   }],
   "npm": {
     "extends": [


### PR DESCRIPTION
## Summary
- add a Renovate package rule for `shiron-dev/actions`
- keep `shiron-dev/actions/**` self-references unpinned in the actions repo

## Why
The shared preset pins GitHub Actions digests by default, but the actions repository should not pin references to itself because releases otherwise cause another self-reference update.

## Checks
- `jq empty default.json`
- `mise exec node@24.17.0 -- corepack pnpm@11.6.0 install --frozen-lockfile`
- `mise exec node@24.17.0 -- corepack pnpm@11.6.0 run test`